### PR TITLE
Added support for multiple seed paths

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,11 +3,21 @@ plugins {
     dbkover.publishing
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 val dbunit_version: String by project
+val junit_version: String by project
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     implementation("org.dbunit:dbunit:$dbunit_version")
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junit_version")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:$junit_version")
+    testImplementation("org.testcontainers:postgresql:1.17.2")
 }

--- a/core/src/main/kotlin/io/dbkover/DBKoverExecutor.kt
+++ b/core/src/main/kotlin/io/dbkover/DBKoverExecutor.kt
@@ -4,6 +4,7 @@ import org.dbunit.Assertion.assertEqualsIgnoreCols
 import org.dbunit.DefaultDatabaseTester
 import org.dbunit.database.DatabaseConfig
 import org.dbunit.database.DatabaseConnection
+import org.dbunit.dataset.CompositeDataSet
 import org.dbunit.dataset.SortedTable
 import org.dbunit.dataset.filter.DefaultColumnFilter
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder
@@ -13,11 +14,11 @@ import java.sql.Connection
 class DBKoverExecutor(
     private val executionConfig: ExecutionConfig,
 ) {
-    fun beforeTest(seedPath: String) {
+    fun beforeTest(seedPath: List<String>) {
         val databaseConnection = getDatabaseConnection()
 
         DefaultDatabaseTester(databaseConnection).apply {
-            dataSet = readDataSet(seedPath)
+            dataSet = CompositeDataSet(seedPath.map { readDataSet(it) }.toTypedArray())
             onSetup()
         }
     }

--- a/core/src/test/kotlin/io/dbkover/DBKoverExecutorTest.kt
+++ b/core/src/test/kotlin/io/dbkover/DBKoverExecutorTest.kt
@@ -1,0 +1,82 @@
+package io.dbkover
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+
+internal class DBKoverExecutorTest {
+
+    private val dbKoverExecutor = DBKoverExecutor(
+        ExecutionConfig { db.createConnection("") }
+    )
+
+    @Test
+    fun `DBKoverExecutor can prepare database prior to test`() {
+        dbKoverExecutor.beforeTest(listOf("test.xml", "test2.xml"))
+
+        val result = db.createConnection("").use {
+            it.prepareStatement("SELECT * FROM test;").executeQuery()
+        }
+
+        assertTrue { result.next() }
+
+        assertEquals(1, result.getLong("id"))
+        assertEquals("Test 1", result.getString("name"))
+        assertEquals("Descriptive text", result.getString("description"))
+
+        assertTrue { result.next() }
+
+        assertEquals(2, result.getLong("id"))
+        assertEquals("Test 2", result.getString("name"))
+        assertNull(result.getString("description"))
+
+        assertTrue { result.next() }
+
+        assertEquals(3, result.getLong("id"))
+        assertEquals("Test 3", result.getString("name"))
+        assertEquals("Descriptive text", result.getString("description"))
+
+        assertFalse { result.next() }
+    }
+
+    @Test
+    fun `DBKoverExecutor can check expected database after test`() {
+        db.createConnection("").use {
+            it.prepareStatement("DELETE FROM test;").execute()
+            it.prepareStatement("INSERT INTO test (id, name, description) VALUES (1, 'Test 1', 'Descriptive text');").execute()
+            it.prepareStatement("INSERT INTO test (id, name) VALUES (2, 'Test 2');").execute()
+        }
+
+        dbKoverExecutor.afterTest("test.xml", arrayOf())
+    }
+
+    companion object {
+        @JvmStatic
+        private val db = PostgreSQLContainer<Nothing>("postgres:13-alpine")
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            db.start()
+
+            db.createConnection("").use {
+                it.prepareStatement("""
+                    CREATE TABLE test (
+                        id bigint primary key,
+                        name varchar(60) not null,
+                        description varchar(255)
+                    );
+                """.trimIndent()).execute()
+            }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            db.stop()
+        }
+    }
+
+}

--- a/core/src/test/resources/test.xml
+++ b/core/src/test/resources/test.xml
@@ -1,0 +1,12 @@
+<dataset>
+    <test
+            id="1"
+            name="Test 1"
+            description="Descriptive text"
+    />
+
+    <test
+            id="2"
+            name="Test 2"
+    />
+</dataset>

--- a/core/src/test/resources/test2.xml
+++ b/core/src/test/resources/test2.xml
@@ -1,0 +1,7 @@
+<dataset>
+    <test
+            id="3"
+            name="Test 3"
+            description="Descriptive text"
+    />
+</dataset>

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    api(project(":core"))
+    implementation(project(":core"))
 
     implementation("org.junit.jupiter:junit-jupiter-api:$junit_version")
     implementation("org.junit.jupiter:junit-jupiter-params:$junit_version")

--- a/junit5/src/main/kotlin/io/dbkover/junit5/DBKoverExtension.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/DBKoverExtension.kt
@@ -4,6 +4,7 @@ import io.dbkover.DBKoverExecutor
 import io.dbkover.ExecutionConfig
 import io.dbkover.junit5.annotation.DBKoverExpected
 import io.dbkover.junit5.annotation.DBKoverDataSet
+import io.dbkover.junit5.exception.ConfigValidationException
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
@@ -23,7 +24,13 @@ class DBKoverExtension : BeforeAllCallback, BeforeTestExecutionCallback, AfterTe
         }
 
         val dbKoverDataSet = context.findAnnotationThrowing(DBKoverDataSet::class.java)
-        context.getExecutor().beforeTest(dbKoverDataSet.path)
+
+        if (dbKoverDataSet.path.isNotBlank() && dbKoverDataSet.paths.isNotEmpty()) {
+            throw ConfigValidationException("'path' and 'paths' is mutual exclusive, please use 'paths' only")
+        }
+
+        val paths = dbKoverDataSet.path.takeIf { it.isNotBlank() }?.let { listOf(it) } ?: dbKoverDataSet.paths.toList()
+        context.getExecutor().beforeTest(paths)
     }
 
     override fun afterTestExecution(context: ExtensionContext) {

--- a/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
@@ -7,5 +7,8 @@ import java.lang.annotation.*
 @MustBeDocumented
 @Inherited
 annotation class DBKoverDataSet(
-    val path: String
+    @Deprecated(message = "Deprecated for adding multi file support", ReplaceWith("paths"))
+    val path: String = "",
+
+    val paths: Array<String> = [],
 )

--- a/junit5/src/main/kotlin/io/dbkover/junit5/exception/ConfigValidationException.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/exception/ConfigValidationException.kt
@@ -1,0 +1,3 @@
+package io.dbkover.junit5.exception
+
+class ConfigValidationException(message: String) : RuntimeException(message)

--- a/junit5/src/test/kotlin/io/dbkover/DBKoverTests.kt
+++ b/junit5/src/test/kotlin/io/dbkover/DBKoverTests.kt
@@ -21,6 +21,13 @@ class DBKoverTests {
         println("In test")
     }
 
+    @Test
+    @DBKoverDataSet(paths = ["test.xml", "test2.xml"])
+    @DBKoverExpected("test.xml")
+    fun `Can run full test with Junit5 and multiple paths`() {
+        println("In test")
+    }
+
     companion object {
         @JvmStatic
         private val db = PostgreSQLContainer<Nothing>("postgres:13-alpine")

--- a/junit5/src/test/resources/test2.xml
+++ b/junit5/src/test/resources/test2.xml
@@ -1,0 +1,3 @@
+<dataset>
+
+</dataset>


### PR DESCRIPTION
Added support for multiple seed paths in JUnit 5 through the following API change.

It deprecates the old `path` property on the `@DBKoverSeedPath` annotation and adds a new `paths` which is an array of string paths.

```kotlin
@DBKoverDataSet(paths = ["file-1.xml", "file-2.xml"])
```

This resolves #5