### PR TITLE
Added clean all tables prior to tests

### DIFF
--- a/junit5/src/main/kotlin/io/dbkover/junit5/DBKoverExtension.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/DBKoverExtension.kt
@@ -30,7 +30,7 @@ class DBKoverExtension : BeforeAllCallback, BeforeTestExecutionCallback, AfterTe
         }
 
         val paths = dbKoverDataSet.path.takeIf { it.isNotBlank() }?.let { listOf(it) } ?: dbKoverDataSet.paths.toList()
-        context.getExecutor().beforeTest(paths)
+        context.getExecutor().beforeTest(paths, dbKoverDataSet.cleanBefore, dbKoverDataSet.cleanBeforeIgnoreTables.toList())
     }
 
     override fun afterTestExecution(context: ExtensionContext) {

--- a/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
@@ -11,4 +11,15 @@ annotation class DBKoverDataSet(
     val path: String = "",
 
     val paths: Array<String> = [],
+
+    /**
+     * Clean all tables before applying data sets.
+     */
+    val cleanBefore: Boolean = false,
+
+    /**
+     * The tables to ignore when cleaning db prior to test.
+     * This could include metadata tables for migration tools etc.
+     */
+    val cleanBeforeIgnoreTables: Array<String> = [],
 )


### PR DESCRIPTION
Added option to clean all tables before applying a data set with a possibility to ignore certain tables.

Added the following API to the JUnit 5 annotations:

```kotlin
@DBKoverDataSet(
  paths = ["dataset.xml"],
  cleanBefore = true,
  cleanBeforeIgnoreTables = ["some_table"],
)
```

Resolves #6 