### PR TITLE
Add support for jsonb datatype in postgres

### DIFF
--- a/core/src/main/kotlin/io/dbkover/DBKoverExecutor.kt
+++ b/core/src/main/kotlin/io/dbkover/DBKoverExecutor.kt
@@ -1,5 +1,6 @@
 package io.dbkover
 
+import io.dbkover.postgres.ExtendedPostgresqlDataTypeFactory
 import org.dbunit.Assertion.assertEqualsIgnoreCols
 import org.dbunit.DefaultDatabaseTester
 import org.dbunit.database.DatabaseConfig
@@ -8,7 +9,6 @@ import org.dbunit.dataset.CompositeDataSet
 import org.dbunit.dataset.SortedTable
 import org.dbunit.dataset.filter.DefaultColumnFilter
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder
-import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory
 import java.sql.Connection
 
 class DBKoverExecutor(
@@ -71,7 +71,7 @@ class DBKoverExecutor(
     private fun getDatabaseConnection() = DatabaseConnection(getConfigConnection(), "public").apply {
         config.setProperty(DatabaseConfig.FEATURE_ALLOW_EMPTY_FIELDS, true)
         config.setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, true)
-        config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, PostgresqlDataTypeFactory())
+        config.setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, ExtendedPostgresqlDataTypeFactory())
     }
 
     private fun readDataSet(path: String) =

--- a/core/src/main/kotlin/io/dbkover/postgres/ExtendedPostgresqlDataTypeFactory.kt
+++ b/core/src/main/kotlin/io/dbkover/postgres/ExtendedPostgresqlDataTypeFactory.kt
@@ -1,0 +1,14 @@
+package io.dbkover.postgres
+
+import io.dbkover.postgres.type.JsonbDataType
+import org.dbunit.dataset.datatype.DataType
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory
+
+class ExtendedPostgresqlDataTypeFactory : PostgresqlDataTypeFactory() {
+    override fun createDataType(sqlType: Int, sqlTypeName: String?): DataType {
+        return when (sqlTypeName) {
+            "jsonb" -> JsonbDataType()
+            else -> super.createDataType(sqlType, sqlTypeName)
+        }
+    }
+}

--- a/core/src/main/kotlin/io/dbkover/postgres/type/JsonbDataType.kt
+++ b/core/src/main/kotlin/io/dbkover/postgres/type/JsonbDataType.kt
@@ -1,0 +1,21 @@
+package io.dbkover.postgres.type
+
+import org.dbunit.dataset.datatype.AbstractDataType
+import org.postgresql.util.PGobject
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Types
+
+class JsonbDataType : AbstractDataType("jsonb", Types.OTHER, String::class.java, false) {
+    override fun typeCast(obj: Any?): Any =obj.toString()
+
+    override fun getSqlValue(column: Int, resultSet: ResultSet): Any? = resultSet.getString(column)
+
+    override fun setSqlValue(value: Any?, column: Int, statement: PreparedStatement) {
+        val jsonObj = PGobject().apply {
+            this.type = "jsonb"
+            this.value = value?.toString()
+        }
+        statement.setObject(column, jsonObj)
+    }
+}

--- a/core/src/test/kotlin/io/dbkover/DBKoverExecutorTest.kt
+++ b/core/src/test/kotlin/io/dbkover/DBKoverExecutorTest.kt
@@ -97,7 +97,8 @@ internal class DBKoverExecutorTest {
                     CREATE TABLE test (
                         id bigint primary key,
                         name varchar(60) not null,
-                        description varchar(255)
+                        description varchar(255),
+                        information jsonb
                     );
                 """.trimIndent()).execute()
 

--- a/core/src/test/resources/test2.xml
+++ b/core/src/test/resources/test2.xml
@@ -3,5 +3,6 @@
             id="3"
             name="Test 3"
             description="Descriptive text"
+            information='{"hello": "world"}'
     />
 </dataset>


### PR DESCRIPTION
This adds the functionality of `jsonb` datatype for the underlaying DbUnit.
It will automatically be applied for the postgres databases.

Resolves #16 