### PR TITLE
Changed cleanBefore to be true per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ DBKover includes the following features:
 DBKover offers integrations with:
 - Junit 5
 
+> **Warning**
+> 
+> The API is still during development and may change without further notice until v1.
+
 ## Installation
 
 Get this package on Maven Central.

--- a/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
@@ -15,7 +15,7 @@ annotation class DBKoverDataSet(
     /**
      * Clean all tables before applying data sets.
      */
-    val cleanBefore: Boolean = false,
+    val cleanBefore: Boolean = true,
 
     /**
      * The tables to ignore when cleaning db prior to test.


### PR DESCRIPTION
Changed default value for clean before to be true.
This means it will always clean tables and starting on a fresh state.

This is a breaking changes but the library is still not released as v1 so I think this is sufficient - I've added a note on this in the README to make it clear that the API is still under development.

Resolves #15 