### PR TITLE
feat: obtain connection from system / application properties

### DIFF
--- a/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
@@ -42,9 +42,5 @@ private fun obtainConnectionFromProperties(): Connection? {
         return null
     }
 
-    val props = Properties()
-    props.setProperty("user", username)
-    props.setProperty("password", password)
-
-    return DriverManager.getConnection(url, props)
+    return DriverManager.getConnection(url, username, password)
 }

--- a/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
@@ -34,9 +34,9 @@ internal fun ExtensionContext.findDataBaseConnectionFactory(): () -> Connection 
 }
 
 private fun obtainConnectionFromProperties(): Connection? {
-    val url: String? = System.getProperty("datasources.default.url")
-    val username: String? = System.getProperty("datasources.default.username")
-    val password: String? = System.getProperty("datasources.default.password")
+    val url: String? = System.getProperty("dbkover.connection.url")
+    val username: String? = System.getProperty("dbkover.connection.username")
+    val password: String? = System.getProperty("dbkover.connection.password")
 
     if (url == null || username == null || password == null) {
         return null

--- a/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
@@ -1,9 +1,12 @@
 package io.dbkover.junit5
 
 import io.dbkover.junit5.annotation.DBKoverConnection
-import org.junit.jupiter.api.extension.*
-import org.junit.platform.commons.util.*
-import java.sql.*
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.platform.commons.util.AnnotationUtils
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.Properties
+
 
 internal fun <T : Annotation> ExtensionContext.hasAnnotation(annotation: Class<T>): Boolean =
     AnnotationUtils.isAnnotated(element, annotation)
@@ -23,7 +26,25 @@ internal fun ExtensionContext.findDataBaseConnectionFactory(): () -> Connection 
             connectionMethod.invoke(requiredTestInstance) as Connection?
                 ?: throw RuntimeException("Connection not initialized correctly")
         }
+    } else if (connectionMethod == null) {
+        return { obtainConnectionFromProperties() ?: throw RuntimeException("Connection not initialized correctly") }
     }
 
     throw RuntimeException("Connection method is missing")
+}
+
+private fun obtainConnectionFromProperties(): Connection? {
+    val url: String? = System.getProperty("datasources.default.url")
+    val username: String? = System.getProperty("datasources.default.username")
+    val password: String? = System.getProperty("datasources.default.password")
+
+    if (url == null || username == null || password == null) {
+        return null
+    }
+
+    val props = Properties()
+    props.setProperty("user", username)
+    props.setProperty("password", password)
+
+    return DriverManager.getConnection(url, props)
 }


### PR DESCRIPTION
If you want to share your database connection across multiple tests, it is currently only possible to do that by using class based inheritance or else it results in a `RuntimeException`. If you'd rather combine multiple annotations into a single one without any inheritance it is not currently possible. I suggest solving this by adding a fallback to system properties, in case that no method is provided by the test class to establish a Connection.