### PR TITLE
feat: Added support for repeatable annotations in Junit5 extension

### DIFF
--- a/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/ExtensionContext.kt
@@ -5,14 +5,8 @@ import org.junit.jupiter.api.extension.*
 import org.junit.platform.commons.util.*
 import java.sql.*
 
-internal fun <T : Annotation> ExtensionContext.hasAnnotation(annotation: Class<T>): Boolean =
-    AnnotationUtils.isAnnotated(element, annotation)
-
-internal fun <T : Annotation> ExtensionContext.findAnnotation(annotation: Class<T>): T? =
-    AnnotationUtils.findAnnotation(element, annotation).orElse(null)
-
-internal fun <T : Annotation> ExtensionContext.findAnnotationThrowing(annotation: Class<T>): T =
-    findAnnotation(annotation) ?: throw RuntimeException("Annotation '${annotation.name}' not present")
+internal fun <T : Annotation> ExtensionContext.findAnnotations(annotation: Class<T>): List<T>
+        = AnnotationUtils.findRepeatableAnnotations(element, annotation)
 
 internal fun ExtensionContext.findDataBaseConnectionFactory(): () -> Connection {
     val connectionMethod = requiredTestClass.findMethodsWithAnnotation(DBKoverConnection::class.java)

--- a/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverDataSet.kt
@@ -2,6 +2,7 @@ package io.dbkover.junit5.annotation
 
 import java.lang.annotation.*
 
+@Repeatable
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented

--- a/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverExpected.kt
+++ b/junit5/src/main/kotlin/io/dbkover/junit5/annotation/DBKoverExpected.kt
@@ -2,6 +2,7 @@ package io.dbkover.junit5.annotation
 
 import java.lang.annotation.*
 
+@Repeatable
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented

--- a/junit5/src/test/kotlin/io/dbkover/DBKoverTests.kt
+++ b/junit5/src/test/kotlin/io/dbkover/DBKoverTests.kt
@@ -28,6 +28,15 @@ class DBKoverTests {
         println("In test")
     }
 
+    @Test
+    @DBKoverDataSet(paths = ["test.xml"])
+    @DBKoverDataSet(paths = ["test2.xml"])
+    @DBKoverExpected("test.xml")
+    @DBKoverExpected("test2.xml")
+    fun `Can run full test with Junit5 and multiple annotations`() {
+        println("In test")
+    }
+
     companion object {
         @JvmStatic
         private val db = PostgreSQLContainer<Nothing>("postgres:13-alpine")


### PR DESCRIPTION
Added support to use multiple `@DBKover` annotations for data sets and expectations. This can be used to e.g apply data setup in different schemas.